### PR TITLE
Fix events display and auto-scroll-to-today functionality

### DIFF
--- a/src/components/CalendarMonth.tsx
+++ b/src/components/CalendarMonth.tsx
@@ -24,16 +24,7 @@ export const CalendarMonth = memo(function CalendarMonth({
     return { monthName, year, month }
   }, [firstDay])
 
-  // Pre-filter events for this month to reduce prop drilling
-  const monthEvents = useMemo(() => {
-    const monthStart = new Date(monthData.year, monthData.month - 1, 1)
-    const monthEnd = new Date(monthData.year, monthData.month, 0)
-    
-    return events.filter(event => {
-      const eventDate = new Date(event.date)
-      return eventDate >= monthStart && eventDate <= monthEnd
-    })
-  }, [events, monthData.year, monthData.month])
+  // Pass all events to CalendarDay to maintain existing filtering logic
 
   return (
     <div className="month-group">
@@ -50,7 +41,7 @@ export const CalendarMonth = memo(function CalendarMonth({
           <CalendarDay
             key={date.toISOString()}
             date={date}
-            events={monthEvents}
+            events={events}
             isToday={isToday(date)}
             todayRef={isToday(date) ? todayRef : undefined}
           />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -177,10 +177,15 @@ export function LinearCalendar() {
       // Complete loading
       setIsInitialLoading(false)
       performanceTracking.stopLoading()
+      
+      // Ensure scroll-to-today happens after calendar is fully rendered
+      setTimeout(() => {
+        jumpToToday()
+      }, 200)
     }
 
     loadingSequence()
-  }, [])
+  }, [jumpToToday])
 
   const totalDays = getTotalDaysInRange(dateRange.startYear, dateRange.endYear)
 


### PR DESCRIPTION
Bug Fixes:
- Remove month-level event pre-filtering that was hiding events from CalendarDay
- Maintain existing event filtering logic in CalendarDay component
- Fix auto-scroll-to-today timing by adding delay after calendar render
- Ensure jumpToToday executes after progressive loading completes

The performance optimizations remain intact while restoring full functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)